### PR TITLE
FIX: allow to play from playlist URI again

### DIFF
--- a/lib/commands/play.js
+++ b/lib/commands/play.js
@@ -33,10 +33,10 @@ module.exports = {
       return
     }
 
-    const matches = argv.uri.match(/spotify:user:(\w+):playlist:([a-zA-Z0-9]{22})/)
+    const matches = argv.uri.match(/(spotify:(user:\w+:)?playlist:|https:\/\/open\.spotify\.com\/playlist\/)([a-zA-Z0-9]{22})/)
 
     if (matches) {
-      const playlist = matches[2]
+      const playlist = matches[3]
       argv.db.logger.info('Adding playlist: ' + playlist)
 
       argv.uri = null


### PR DESCRIPTION
Enhanced playlist detection regexp. Now supports two styles:

```
play https://open.spotify.com/playlist/4Sh1304b6IwMKA3GXi5PYK?si=GjJzr5h_SKq5QL28Sen2wQ
play spotify:playlist:4Sh1304b6IwMKA3GXi5PYK
```

Other formats (with username in URL) seem to be deprecated anyway.